### PR TITLE
Download button now appears correctly after a pull

### DIFF
--- a/cfts/static/js/queue.js
+++ b/cfts/static/js/queue.js
@@ -56,11 +56,14 @@ jQuery( document ).ready( function() {
           alert( 'Pull complete. New ZIP file created for ' + netName + '.  Click the download button to retrieve it.' );
           
           // prevent a second pull
-          pullBtn.addClass( 'disabled' );
+          //pullBtn.addClass( 'disabled' );
+          $('.pull-button').addClass('disabled');
 
           // update link on page to avoid unnecessary refresh 
           downloadBtn = $( '#dl' + netName );
           downloadBtn.attr( 'href', '/static/files/' + netName + '_' + resp.pullNumber + '.zip' );
+          downloadBtn.text('Download Current '+ netName + ' Zip')
+          downloadBtn.attr('hidden', false);
           downloadBtn.focus();
 
           // update last pulled info

--- a/templates/pages/queue.html
+++ b/templates/pages/queue.html
@@ -49,11 +49,18 @@
                         <div class="create-pull">
                             <button class="btn btn-primary pull-button{% if network.pending.count == 0 %} disabled{% endif %}" id="pull{{network.name}}">Create {{ network.name }} Pull</button>                                 
                         </div>
-                        {% for lp in network.last_pull %}
+                        {% if network.last_pull.count > 0 %}
+                            {% for lp in network.last_pull %}
+                            <div class="download-block">
+                                <a class="btn btn-primary download-button" id="dl{{network.name}}"
+                                    href="/static/files/{{ network.name }}_{{ lp.pull_number }}.zip">Download Current {{ network.name }} Zip</a>
+                                </div>
+                                {% endfor %}
+                        {% else %}
                         <div class="download-block">
-                            <a class="btn btn-primary download-button" id="dl{{network.name}}" href="/static/files/{{ network.name }}_{{ lp.pull_number }}.zip">Downoad Current {{ network.name }} Zip</a>
+                            <a class="btn btn-primary download-button" id="dl{{network.name}}" href="#" hidden></a>
                         </div>
-                        {% endfor %}
+                        {% endif %}
                         
                     </div>
 


### PR DESCRIPTION
Pull download button will appear in the queue page after initial pull without the need for a page refresh.