### PR TITLE
fixed scan tool removing first result on subsequent scans

### DIFF
--- a/cfts/static/js/scan.js
+++ b/cfts/static/js/scan.js
@@ -1,5 +1,6 @@
 window.document.title = "CFTS -- Scan Tool";
 scanForm = document.querySelector( "#scanForm" );
+firstScan = true
 
 // Add the CSRF token to ajax requests
 $.ajaxSetup({
@@ -51,7 +52,10 @@ const processResults = function( results ) {
     }
     
     section.style.display = "block";
-    rootList.removeChild( rootItem );
+    if(firstScan == true){
+      rootList.removeChild( rootItem );
+      firstScan = false;
+    };
 
   } catch ( err ) {
     console.log( err.message );


### PR DESCRIPTION
Before if a first scan was run on a zip with X number of files and a second scan was run with Y number of files the scan page would cut one of the results and display X + Y - 1 scan result.

Scan results no longer get cut on new scans.