### PR TITLE
Scan tool pdf support

### DIFF
--- a/pages/views/scan.py
+++ b/pages/views/scan.py
@@ -61,7 +61,6 @@ def runScan():
             if(ext in office_filetype_list):
                 file_results = scanOfficeFile(file_path)
             elif(ext == '.pdf'):
-                print(filename)
                 textFile = open(root+"\\"+temp+".txt", "w")
                 pdf2Text = StringIO()
                 with open(file_path, 'rb') as pdf:
@@ -76,7 +75,6 @@ def runScan():
                 os.remove(text_path)
 
             else:
-                print(filename)
                 file_results = scanFile(file_path)
 
             if(file_results is not None):

--- a/pages/views/scan.py
+++ b/pages/views/scan.py
@@ -1,5 +1,7 @@
-import os, re, shutil
-#====================================================================
+import os
+import re
+import shutil
+# ====================================================================
 # core
 from zipfile import ZipFile
 from django.conf import settings
@@ -14,131 +16,142 @@ from django.http import JsonResponse
 # pdf parsing
 from io import StringIO
 from pdfminer.high_level import *
-#====================================================================
+# ====================================================================
+
 
 @login_required
-def scan( request ):
-  # request context
-  rc = {
-    'bodyText': 'Scan Tool'
-  }
+def scan(request):
+    # request context
+    rc = {
+        'bodyText': 'Scan Tool'
+    }
 
-  # POST
-  if request.method == 'POST':
-    form_files = request.FILES
+    # POST
+    if request.method == 'POST':
+        form_files = request.FILES
 ##    print( form_files )
 
-    for i, f in enumerate( form_files.getlist( "toScan" ) ):
-      zf = ZipFile( f )
-      zf.extractall( settings.SCANTOOL_DIR )
-      results = runScan()
+        for i, f in enumerate(form_files.getlist("toScan")):
+            zf = ZipFile(f)
+            zf.extractall(settings.SCANTOOL_DIR)
+            results = runScan()
 
-    # clean up after yourself
-    cleanup(settings.SCANTOOL_DIR)
-    return JsonResponse( results, safe=False )
+        # clean up after yourself
+        cleanup(settings.SCANTOOL_DIR)
+        return JsonResponse(results, safe=False)
 
-  # GET
-  return render( request, 'pages/scan.html', { 'rc': rc } )
+    # GET
+    return render(request, 'pages/scan.html', {'rc': rc})
+
 
 def runScan():
-  scan_results = []
-  office_filetype_list = [ ".docx", ".dotx", ".xlsx", ".xltx", ".pptx", ".potx", ".ppsx", ".onenote" ]
-  scan_dir = os.path.abspath( settings.SCANTOOL_DIR )
+    scan_results = []
+    office_filetype_list = [".docx", ".dotx", ".xlsx",
+                            ".xltx", ".pptx", ".potx", ".ppsx", ".onenote"]
+    scan_dir = os.path.abspath(settings.SCANTOOL_DIR)
 
-  # \cfts\scan should contain all the user folders from the zip file
-  for root, subdirs, files in os.walk( scan_dir ):
-    for filename in files:
-      file_results = None
-      file_path = os.path.join( root, filename )
+    # \cfts\scan should contain all the user folders from the zip file
+    for root, subdirs, files in os.walk(scan_dir):
+        for filename in files:
+            file_results = None
+            file_path = os.path.join(root, filename)
 ##      print( '\t- file %s (full path: %s)' % ( filename, file_path ) )
-      temp, ext = os.path.splitext( filename )
+            temp, ext = os.path.splitext(filename)
 
-      if( ext in office_filetype_list ):
-        file_results = scanOfficeFile( file_path )
-      elif(ext == '.pdf'):
-        textFile = open(root+"\\"+temp+".txt", "w")
-        pdf2Text = StringIO()
-        with open(file_path, 'rb') as pdf:
-          extract_text_to_fp(pdf, pdf2Text, output_type='text', codec='utf-8')
-          textFile.write(pdf2Text.getvalue().strip())
-          textFile.close()
+            if(ext in office_filetype_list):
+                file_results = scanOfficeFile(file_path)
+            elif(ext == '.pdf'):
+                print(filename)
+                textFile = open(root+"\\"+temp+".txt", "w")
+                pdf2Text = StringIO()
+                with open(file_path, 'rb') as pdf:
+                    extract_text_to_fp(
+                        pdf, pdf2Text, output_type='text', codec='utf-8')
+                    textFile.write(pdf2Text.getvalue().strip())
+                    textFile.close()
 
-        text_path = os.path.join(root+"\\"+temp+".txt")
-        file_results = scanFile(text_path)
-        file_results['file'] = file_path
+                text_path = os.path.join(root+"\\"+temp+".txt")
+                file_results = scanFile(text_path)
+                file_results['file'] = file_path
+                os.remove(text_path)
 
-      else:
-        file_results = scanFile( file_path )
+            else:
+                print(filename)
+                file_results = scanFile(file_path)
 
-      if( file_results is not None ):
-        result = {}
-        result['file'] = file_path
-        result['found'] = file_results
-        scan_results.append( result )  
+            if(file_results is not None):
+                result = {}
+                result['file'] = file_path
+                result['found'] = file_results
+                scan_results.append(result)
 
-  #print(scan_results)
-  return scan_results
+    return scan_results
 
-def scanOfficeFile( office_file ):
-  results = None
-  
-  # treat as a zip and extract to \cfts\scan\temp directory
-  zf = ZipFile( office_file )
-  zf.extractall( settings.SCANTOOL_TEMPDIR )
 
-  # step through the contents of the scantool 'temp' folder
-  for root, subdirs, files in os.walk( settings.SCANTOOL_TEMPDIR ):
-    for filename in files:
-      file_path = os.path.join( root, filename )
-      findings = scanFile( file_path )
-      if( findings is not None ):
-        if( results is None ):
-          results = []
-        results.append( findings )
-  
-  # clean up after yourself
-  #cleanup( settings.SCANTOOL_TEMPDIR )
-  #done
-  return results
+def scanOfficeFile(office_file):
+    results = None
+
+    # treat as a zip and extract to \cfts\scan\temp directory
+    zf = ZipFile(office_file)
+    zf.extractall(settings.SCANTOOL_TEMPDIR)
+
+    # step through the contents of the scantool 'temp' folder
+    for root, subdirs, files in os.walk(settings.SCANTOOL_TEMPDIR):
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            findings = scanFile(file_path)
+            if(findings is not None):
+                if(results is None):
+                    results = []
+                results.append(findings)
+
+    # clean up after yourself
+    # done
+    return results
 
 
 def scanFile(text_file):
-  result = None
-  
-  dirty_word_list =  [ "SECRET", "S//", "NOFORN", "C//", "CONFIDENTIAL", "PRV", "LVY" ]
-  reg_lst = []
-  for raw_regex in dirty_word_list:
-    reg_lst.append( re.compile( raw_regex ) )
-
-  try:
-    with open( text_file, "r", encoding="utf-8") as f:
-      f_content = f.read()
-      result = { 
+    result = {
         'file': text_file,
         'findings': []
-      }
-      for compiled_reg in reg_lst:  
-        found = re.finditer( compiled_reg, f_content )
-        for match in found:
-          #result['findings'].append( '%s <br/> %s (%s)' % ( match.string, match.group(), match.start() ) )
-          result['findings'].append(
-              'This file contains the term: %s' % (match.group()))
-      if not len( result['findings'] ):
-        result = None
-    
-  except UnicodeDecodeError:
-    # Found non-text data
-    result = { 'file': text_file, 'findings': ['Unable to scan file.'] }
+    }
 
-  return result
+    dirty_word_list = ["SECRET", "S//", "NOFORN",
+                       "C//", "CONFIDENTIAL", "PRV", "LVY"]
+    reg_lst = []
+    for raw_regex in dirty_word_list:
+        reg_lst.append(re.compile(raw_regex))
 
-def cleanup( folder ):
-  for oldfile in os.listdir( folder ):
-    old = os.path.join( folder, oldfile )
     try:
-        if os.path.isfile( old ) or os.path.islink( old ):
-            os.unlink( old )
-        elif os.path.isdir( old ):
-            shutil.rmtree( old )
-    except Exception as e:
-      print( 'Failed to delete %s. Reason: %s' % ( old, e ) )
+        with open(text_file, "r", encoding="utf-8") as f:
+            f_content = f.read()
+            # result = {
+            #    'file': text_file,
+            #    'findings': []
+            # }
+            for compiled_reg in reg_lst:
+                found = re.finditer(compiled_reg, f_content)
+                for match in found:
+                    #result['findings'].append( '%s <br/> %s (%s)' % ( match.string, match.group(), match.start() ) )
+                    result['findings'].append(
+                        'This file contains the term: %s' % (match.group()))
+            if not len(result['findings']):
+                result['findings'].append("Scan returned no dirty words.")
+
+    except UnicodeDecodeError:
+        # Found non-text data
+        result = {'file': text_file, 'findings': ['Unable to scan file.']}
+
+    return result
+
+
+def cleanup(folder):
+    for oldfile in os.listdir(folder):
+        old = os.path.join(folder, oldfile)
+        try:
+            if os.path.isfile(old) or os.path.islink(old):
+                os.unlink(old)
+            elif os.path.isdir(old):
+                shutil.rmtree(old)
+        except Exception as e:
+            print('Failed to delete %s. Reason: %s' % (old, e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ six==1.14.0
 sqlparse==0.3.0
 typed-ast==1.4.1
 wrapt==1.11.2
+pdfminer.six==20201018


### PR DESCRIPTION
This allows pdf's to be scanned for dirty words in the scan tool. When a pdf is scanned the file is converted to a .txt file that is stored in the temp scan directory. This .txt file is then passed back to the scan tool in place of the pdf and is searched for dirty words. 

My testing returned the following results:

- pdf with no dirty words:  no hits from scan tool
- pdf with dirty words:  all dirty words found with scan tool
- pdf with dirty words layered under an image (hidden dirty word):  all dirty words found including ones hidden behind images