### PR TITLE
can no longer create empty centcom only pull

### DIFF
--- a/cfts/static/js/queue.js
+++ b/cfts/static/js/queue.js
@@ -53,7 +53,13 @@ jQuery( document ).ready( function() {
     let url = '/create-zip/' + netName +'/'+ isCentcom;
     
     if( $( e.target ).hasClass( 'disabled' ) ) {
+      if( $(e.target).hasClass('centcom') ){
+      alert( 'There are no pending CENTCOM transfer requests to pull for this network.' )
+      }
+      else{
       alert( 'There are no pending transfer requests to pull for this network.' )
+      }
+
     } else {
       $.get( url, {}, ( resp, status ) => {
         if( status == 'success' ) { 

--- a/pages/views/queue.py
+++ b/pages/views/queue.py
@@ -69,6 +69,7 @@ def queue(request):
             'count': ds_requests.count(),
             'pending': ds_requests.aggregate(count=Count('request_id', filter=Q(pull__date_pulled__isnull=True))),
             'q': ds_requests,
+            'centcom': ds_requests.aggregate(count=Count('request_id', filter=Q(pull__date_pulled__isnull=True, centcom_pull=True))),
             'last_pull': last_pull
         }
         # ... and add it to the list

--- a/templates/pages/queue.html
+++ b/templates/pages/queue.html
@@ -48,7 +48,7 @@
                         </div>
                         <div class="create-pull">
                             <button class="btn btn-primary pull-button{% if network.pending.count == 0 %} disabled{% endif %}" id="pull{{network.name}}">Create {{ network.name }} Pull</button> 
-                            <button class="btn btn-warning pull-button centcom{% if network.pending.count == 0 %} disabled{% endif %}" id="pull{{network.name}}">Pull only Centcom</button> 
+                            <button class="btn btn-warning pull-button centcom{% if network.centcom.count == 0 %} disabled{% endif %}" id="pull{{network.name}}">Pull only Centcom</button> 
                       
                             
                         </div>


### PR DESCRIPTION
Fixes a bug that allowed a user to create a centcom only pull when there were no centcom only requests in the transfer queue. This would result in an empty pull.