### PR TITLE
removed 'login_required' decorator from process request api

### DIFF
--- a/pages/views/apis.py
+++ b/pages/views/apis.py
@@ -180,7 +180,6 @@ def runNumbers(request):
 
     return JsonResponse({'files_reviewed': files_reviewed, 'files_transfered': files_transfered, 'files_rejected': files_rejected, 'centcom_files': centcom_files, 'file_types': file_type_counts, 'file_sizes': str(round(file_size,2))+" "+sizeSuffix[i] })
 
-@login_required
 def process ( request ):
     resp = {}
   


### PR DESCRIPTION
- this was preventing users without a django user account (most end users) from submitting requests