### PR TITLE
fix to transfer archive Centcom noting

### DIFF
--- a/templates/pages/archive.html
+++ b/templates/pages/archive.html
@@ -67,7 +67,7 @@
                 {% endfor %}
             </ul>
         </td>
-        <td class="xfer-pull">{% if r.is_centcom %}
+        <td class="xfer-pull">{% if r.pull.centcom_pull %}
         {{r.pull}} Centcom Only
         {% else %}{{ r.pull }}
         {% endif %}</td>


### PR DESCRIPTION
- pull column of archive page now checks the centcom field of a pull rather than the request to display the "Centcom" note after the pull number