### PR TITLE
PKI fall back fix

### DIFF
--- a/pages/views/apis.py
+++ b/pages/views/apis.py
@@ -216,7 +216,7 @@ def process ( request ):
                 name_first=form_data.get('firstName'),
                 name_last=form_data.get('lastName'),
                 email=source_email,
-                user_identifier=form_data.get('userID')
+                phone=form_data.get('userPhone')
             )
             user.save()
 
@@ -231,6 +231,7 @@ def process ( request ):
                     name_first=form_data.get('firstName'),
                     name_last=form_data.get('lastName'),
                     email=source_email,
+                    phone=form_data.get('userPhone'),
                     user_identifier=form_data.get('userID')
                 )
                 user.save()

--- a/pages/views/frontend.py
+++ b/pages/views/frontend.py
@@ -17,11 +17,15 @@ def frontend(request):
     resources = ResourceLink.objects.all()
     try:
         cert = request.META['CERT_SUBJECT']
-        userHash = hashlib.md5()
-        userHash.update(cert.encode())
-        userHash = userHash.hexdigest()
-        rc = {'networks': nets, 'resources': resources,
-              'cert': cert, 'userHash': userHash}
+        
+        if cert =="":
+            rc = {'networks': nets, 'resources': resources, }
+        else:
+            userHash = hashlib.md5()
+            userHash.update(cert.encode())
+            userHash = userHash.hexdigest()
+            rc = {'networks': nets, 'resources': resources,
+                'cert': cert, 'userHash': userHash}
     except KeyError:
         rc = {'networks': nets, 'resources': resources, }
     #  for rl in resources:


### PR DESCRIPTION
Turns out IIS sends blank client cert headers when SSL isn't enforced
python saw a blank header as a header and processed it like a normal cert header
also user phone numbers get saved now