### PR TITLE
rejection email template

### DIFF
--- a/cfts/static/js/queue.js
+++ b/cfts/static/js/queue.js
@@ -36,7 +36,7 @@ jQuery( document ).ready( function() {
     beforeSend: function( xhr, settings ) {
       xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
     } 
-   });
+  });
 
   // PULL BUTTON CLICK HANDLER
   $( '.pull-button' ).click( e => {
@@ -64,7 +64,7 @@ jQuery( document ).ready( function() {
       $('.pull-button').prop('disabled', true);
 
       $.get( url, {}, 'json').then(
-	function(resp, status){
+        function(resp, status){
           // TODO: AJAX success != pull success
           // display success to the user
           alert( 'Pull complete. New ZIP file created for ' + netName + '.  Click the download button to retrieve it.' );
@@ -83,19 +83,19 @@ jQuery( document ).ready( function() {
           // update last pulled info
           $( '.last-pull-info .date-pulled' ).text( resp.datePulled );
           $( '.last-pull-info .user-pulled' ).text( resp.userPulled );
-	  notifyUserSuccess("Pull Created Successfully")
+          notifyUserSuccess("Pull Created Successfully")
 
           $( "#forceReload" ).submit();
 
         }, 
 
-	function(resp, status){
-            console.error( 'Shit broke, yo.' );
-	    alert("Failed to create pull, send error message to web team.")
-            responseText = resp.responseText
-	    errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
+        function(resp, status){
+          console.error( 'Shit broke, yo.' );
+          alert("Failed to create pull, send error message to web team.")
+          responseText = resp.responseText
+          errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
 
-	    notifyUserError("Error Creating Pull, send error message to web team:  " + errorInfo)
+          notifyUserError("Error Creating Pull, send error message to web team:  " + errorInfo)
         }
       );
     }
@@ -188,7 +188,7 @@ const sendUnrejectRequest = (data) => {
     let id_list = [];
       data.forEach( ( f ) => {
         id_list.push( f.fileID ) 
-       });
+      });
 
       const postData = {
         'request_id': data[0]['requestID'],  // doesn't matter which request we grab
@@ -198,19 +198,19 @@ const sendUnrejectRequest = (data) => {
       const setUnrejectOnFiles = $.post( '/api-unreject', postData, 'json' ).then( 
         // success
         function( resp, status ) {
-           console.log( 'SUCCESS' );        
-           notifyUserSuccess("File Unreject Successful")
-	   $( "#forceReload" ).submit();
+          console.log( 'SUCCESS' );        
+          notifyUserSuccess("File Unreject Successful")
+          $( "#forceReload" ).submit();
         },
         // fail 
         function( resp, status ) {
-           console.log( 'FAIL' );
+          console.log( 'FAIL' );
 
-	   alert("Failed to unreject files, send error message to web team.")
-	   responseText = resp.responseText
-	   errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
+          alert("Failed to unreject files, send error message to web team.")
+          responseText = resp.responseText
+          errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
 
-           notifyUserError("Error unrejecting file, send error message to web team: " + errorInfo)
+          notifyUserError("Error unrejecting file, send error message to web team: " + errorInfo)
            //console.log( 'Server response: ' + JSON.stringify(resp,null, 4));
           // console.log( 'Response status: ' + status );
         }
@@ -271,7 +271,7 @@ const sendUnrejectRequest = (data) => {
     let id_list = [];
       data.forEach( ( f ) => {
         id_list.push( f.fileID ) 
-       });
+      });
 
       const postData = {
         'request_id': data[0]['requestID'],  // doesn't matter which request we grab
@@ -281,19 +281,19 @@ const sendUnrejectRequest = (data) => {
       const setEncryptOnFiles = $.post( '/api-setencrypt', postData, 'json' ).then( 
         // success
         function( resp, status ) {
-           console.log( 'SUCCESS' );        
-           notifyUserSuccess("File Encryption Successful")
-	   $( "#forceReload" ).submit();
+          console.log( 'SUCCESS' );        
+          notifyUserSuccess("File Encryption Successful")
+          $( "#forceReload" ).submit();
         },
         // fail 
         function( resp, status ) {
-           console.log( 'FAIL' );
+          console.log( 'FAIL' );
 
-	   alert("Failed to encrypt files, send error message to web team.")
-	   responseText = resp.responseText
-	   errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
+          alert("Failed to encrypt files, send error message to web team.")
+          responseText = resp.responseText
+          errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
 
-           notifyUserError("Error encrypting file, send error message to web team: " + errorInfo)
+          notifyUserError("Error encrypting file, send error message to web team: " + errorInfo)
            //console.log( 'Server response: ' + JSON.stringify(resp,null, 4));
           // console.log( 'Response status: ' + status );
         }
@@ -321,7 +321,6 @@ const sendUnrejectRequest = (data) => {
 
       $(e.target).text("Show Duplicates")
       $(e.target).removeClass('dupes-visable')
-     
       
     }
 
@@ -337,7 +336,6 @@ const sendUnrejectRequest = (data) => {
     }
 
   });
- 
 
   // REJECTION MODAL DEFINITIONS (POPUP)
   const checkSelection = ( selector ) => {
@@ -369,7 +367,7 @@ const sendUnrejectRequest = (data) => {
       let id_list = [];
       data.forEach( ( f ) => {
         id_list.push( f.fileID ) 
-       });
+      });
 
       const postData = {
         'reject_id': $this.val(),
@@ -380,13 +378,14 @@ const sendUnrejectRequest = (data) => {
       const setRejectOnFiles = $.post( '/api-setreject', postData, 'json' ).then( 
         // success
         function( resp ) {
-           console.log( 'SUCCESS' );
-           notifyUserSuccess("File rejection Successful")
-           console.log( 'Server response: ' + JSON.stringify(resp,null, 4));
+          console.log( 'SUCCESS' );
+          notifyUserSuccess("File rejection Successful")
+          //console.log( 'Server response: ' + resp);
 
-      // download eml file      
-      let $anchor = $( "<a class='emailLink' target='_blank' href='/api-geteml/"+ resp.emlName +"'></a>" );
+      // create mailto anchor
+      let $anchor = $( "<a class='emailLink' target='_blank' href='" + resp + "''></a>" );
       $( document.body ).append( $anchor );
+      
       $( '.emailLink' ).each( function() { $(this)[0].click(); } );  
 	
 
@@ -400,14 +399,14 @@ const sendUnrejectRequest = (data) => {
         // fail 
         function( resp, status ) {
 	   // close the dialog
-           $( theDialog ).dialog( 'close' );
-	   alert("Failed to reject files, send error message to web team.")
+          $( theDialog ).dialog( 'close' );
+          alert("Failed to reject files, send error message to web team.")
 
-           console.log( 'FAIL' );
-	   responseText = resp.responseText
-	   errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
+          console.log( 'FAIL' );
+          responseText = resp.responseText
+          errorInfo = responseText.substring(resp.responseText.indexOf("Exception Value"), resp.responseText.indexOf("Python Executable"))
 
-           notifyUserError("Error rejecting file, send error message to web team: " + errorInfo)
+          notifyUserError("Error rejecting file, send error message to web team: " + errorInfo)
            //console.log( 'Server response: ' + JSON.stringify(resp,null, 4));
           // console.log( 'Response status: ' + status );
         }

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -60,7 +60,6 @@ urlpatterns = [
     path('api-processrequest', views.process, name='api-processrequest'),
     path('api-setconsentcookie', views.setConsentCookie, name='api-setconsentcookie'),
     path('api-getclassifications', views.getClassifications, name='api-getclassifications'),
-    path('api-geteml/<str:emlName>', views.getEml, name='api-geteml'),
     path('api-removeCentcom/<uuid:id>', views.removeCentcom, name='api-removeCentcom'),
     path('api-requestnotes/<uuid:requestid>', views.requestNotes, name='api-requestnotes'),
 

--- a/templates/partials/Queue_partials/rejectionEmailTemplate.html
+++ b/templates/partials/Queue_partials/rejectionEmailTemplate.html
@@ -1,16 +1,19 @@
 {% load util %}
 
 {% block email%}
+%0D%0A%0D%0A
 As a customer it is your responsibility to follow the policies that govern the use of this service.
-
+%0D%0A%0D%0A
 Our policy is available on the main page of CFTS.
-
-Continued failure to follow our policy will result in you no longer being able to utilize our service.
-
-----------------------------------------------------------------------------------------------------------------------------------------------------
+%0D%0A%0D%0A
+Continued failure to follow our policy may result in you no longer being able to utilize our service.
+%0D%0A%0D%0A
+-----------------------------------------------------------
+%0D%0A
 Request: {{rqst.user.name_last}}, {{firstName}} ({{ rqst.date_created|date:'d M' }} {{ rqst.date_created|time:'H:i:s' }})
-Click <a href="{{request.get_host}}{% url 'userRequests' rqst.request_id %}">here</a> to see your request details.
-
+%0D%0A
+To see the details of your request click the following link: {{url}}
+%0D%0A%0D%0A
 Rejection reason: {{rejection.subject}}
 
 {% endblock %}


### PR DESCRIPTION
- create Django template for generic rejection email with filled in request info
- email template includes a link to the request details page so users can get more information about the rejection
- fully rendered template will then be turned into a mailto anchor on page
- "solves" server file generation issues... finally