### PR TITLE
Add messages to user edit info page

### DIFF
--- a/cfts/settings.py
+++ b/cfts/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 import cfts.network as ENV
+from django.contrib.messages import constants as messages
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -47,6 +48,14 @@ INSTALLED_APPS = [
 ]
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
+
+MESSAGE_TAGS = {
+    messages.DEBUG: 'alert-secondary',
+    messages.INFO: 'alert-info',
+    messages.SUCCESS: 'alert-success',
+    messages.WARNING: 'alert-warning',
+    messages.ERROR: 'alert-danger',
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/cfts/static/css/frontend.css
+++ b/cfts/static/css/frontend.css
@@ -109,9 +109,8 @@ input[type="checkbox"] {
   text-align: center;
 }
 
-span.isCentcom {
+h6.isCentcom {
   text-align: left;
-  font-size: 0.90rem;
 }
 
 .required {

--- a/pages/forms.py
+++ b/pages/forms.py
@@ -91,7 +91,7 @@ class userInfoForm(ModelForm):
     
     def validate_org(self, form):
         if form.get('org') == "None":
-            self.add_error('org', "Select an Organization")
+            self.add_error('org', "Select an organization")
 
         if form.get('org') == "OTHER" and form.get('other_org')=="":
             self.add_error('other_org', "List your organization")

--- a/pages/views/auth.py
+++ b/pages/views/auth.py
@@ -288,6 +288,7 @@ def editUserInfo(request):
             
             return redirect("/frontend")
         else:
+            messages.error(request, "Required fields missing")
             return render(request, 'authForms/editUserInfo.html', context={'resources': resources, "userInfoForm": form})
 
     form = userInfoForm(instance=cftsUser, networks=nets)

--- a/pages/views/frontend.py
+++ b/pages/views/frontend.py
@@ -2,6 +2,7 @@
 # core
 from datetime import date
 from django.core import paginator
+from django.contrib import messages
 
 # crypto
 import hashlib
@@ -61,6 +62,7 @@ def frontend(request):
                     if cftsUser == None:
                         return redirect("/login")
                     elif cftsUser.update_info == True:
+                        messages.info(request, "Update all required fields")
                         return redirect("/user-info")
 
                     nets = getDestinationNetworks(request, cftsUser)
@@ -81,6 +83,7 @@ def frontend(request):
                         if cftsUser == None:
                             return redirect("/login")
                         elif cftsUser.update_info == True:
+                            messages.info(request, "Fill out all required fields.")
                             return redirect("/user-info")
 
                         nets = getDestinationNetworks(request, cftsUser)
@@ -101,6 +104,7 @@ def frontend(request):
                     if cftsUser == None:
                         return redirect("/login")
                     elif cftsUser.update_info == True:
+                        messages.info(request, "Fill out all required fields.")
                         return redirect("/user-info")
 
                     nets = getDestinationNetworks(request, cftsUser)

--- a/templates/authForms/editUserInfo.html
+++ b/templates/authForms/editUserInfo.html
@@ -6,6 +6,9 @@
 <link rel="stylesheet" href="{% static 'css/authForms.css' %}" />
 
 <div class="container py-5">
+    
+    {% include 'partials/messages.html' %}
+
     <h1 class="mb-3">Update Account Info</h1>
     <form class="needs-validation" method="post" novalidate>
         {% crispy userInfoForm %}

--- a/templates/pages/frontend.html
+++ b/templates/pages/frontend.html
@@ -76,7 +76,7 @@
                   aria-describedby="userPhoneHelp userPhoneRequired" placeholder="Phone Number" readonly>
                 </div>
                 
-                <span class="form-text isCentcom mb-3">Organization:</span>
+                <h6 class="form-text isCentcom mb-3">Organization:</h6>
                 <div class="form-group input-group ">
                   <div class="input-group-prepend">
                     <span class="input-group-text">*</span>
@@ -130,14 +130,20 @@
             <div class="card text-center border-secondary mb-resp bg-light">
               <div class="card-body">
                 <h3 class="text-gray-dark">Transfer To</h3>
-                <div style="display: grid; grid-template-columns: 50% 50%;">
-                  {% for net, email in rc.networks.items %}
-                  <div class="custom-control custom-switch text-left" style="margin: 0.5em 0;">
-                    <input type="radio" name="network" class="custom-control-input network-switch" id="switch{{ net }}" value="{{ net }}" email="{{ email }}"/>
-                    <label class="custom-control-label" for="switch{{ net }}">{{ net }}</label>
+                {% if rc.networks.items|length > 0%}
+                  <div style="display: grid; grid-template-columns: 50% 50%;">
+                    {% for net, email in rc.networks.items %}
+                    <div class="custom-control custom-switch text-left" style="margin: 0.5em 0;">
+                      <input type="radio" name="network" class="custom-control-input network-switch" id="switch{{ net }}" value="{{ net }}" email="{{ email }}"/>
+                      <label class="custom-control-label" for="switch{{ net }}">{{ net }}</label>
+                    </div>                    
+                    {% endfor %}
                   </div>
-                  {% endfor %}
-                </div>
+                {% else %}
+                  <h6 class="text-gray-dark">To add destination networks, save valid emails <a href="{% url 'user-info' %}">here</a></h6>
+                {% endif %}
+
+                
                 <h3 class="text-gray-dark">Destination Email</h3>
                 <div class="form-group input-group" id="targetEmailGroup">
                   <div class="input-group-prepend">

--- a/templates/partials/messages.html
+++ b/templates/partials/messages.html
@@ -1,0 +1,8 @@
+{% for message in messages %}
+    <div class="alert {{message.tags}} alert-dismissible" role="alert">
+        <button class="close" style="padding-top: .4rem; padding-right: 1rem;" type="button" data-dismiss="alert">
+            <span>&times;</span>
+        </button>
+        {{message}}
+    </div>
+{% endfor %}


### PR DESCRIPTION
- should help eliminate confusion when users are forced to this page after a User model update
- messages.html can be added to pages in the future to allow for notifying users between pages
- added instructions on transfer request page for adding destination networks when a user has none