### PR TITLE
Prevent users from creating duplicate accounts...

### DIFF
--- a/pages/forms.py
+++ b/pages/forms.py
@@ -37,7 +37,17 @@ class NewUserForm(UserCreationForm):
         if commit:
             user.save()
         return user
+    
+    def check_duplicate(self, form, certInfo):
+        if certInfo['status'] == "validPKI":
+            matchingUsers = User.objects.filter(user_identifier=certInfo['userHash'])
+            if matchingUsers.count() != 0:
+                self.add_error(None, "Your " + NETWORK + " token is already tied to an account. If you forgot your password you can request a reset from the login page. If you believe this to be an error please contact us at the link below.")
 
+        else:
+            matchingUsers = User.objects.filter(source_email__address=form.get('email'))
+            if matchingUsers.count() != 0:
+                self.add_error(None, "You email is already tied to an account. If you forgot your password you can request a reset from the login page. If you believe this to be an error please contact us at the link below.")
 class userInfoForm(ModelForm):
     source_email = forms.EmailField(max_length=50, required=True)
     phone = forms.CharField(max_length=50 ,required=True)

--- a/pages/views/auth.py
+++ b/pages/views/auth.py
@@ -195,11 +195,11 @@ def register(request):
 
     if request.method == "POST":
         form = NewUserForm(request.POST)
-        
+        certInfo = getCert(request)
+        form.check_duplicate(request.POST, certInfo)
         if form.is_valid():
             user = form.save()
             login(request, user)
-            certInfo = getCert(request)
             cftsUser = getOrCreateUser(request, certInfo)
             cftsUser.auth_user = authUser.objects.get(id=request.user.id)
             cftsUser.phone = request.POST.get('phone')


### PR DESCRIPTION
- ...or at least attempt to 
- add duplicate user account validation to register form
- users with validPKI will have their cert hash used to search for CFTS User records with that hash
- users with buggedPKI will have the source email they entered in the form used to search for CFTS User records with that source email
- any match will throw a validation error preventing the user from creating an account